### PR TITLE
Fix mailinator provider URL

### DIFF
--- a/src/providers.js
+++ b/src/providers.js
@@ -1,6 +1,6 @@
 var providers = [
   {name: "Dispostable", domain: "dispostable.com", inbox_url: "http://www.dispostable.com/inbox/"},
-  {name: "mailinator", domain: "mailinator.com", inbox_url: "http://mailinator.com/maildir.jsp?email="},
+  {name: "mailinator", domain: "mailinator.com", inbox_url: "https://www.mailinator.com/inbox2.jsp?public_to="},
   {name: "mailcatch", domain: "mailcatch.com", inbox_url: "http://mailcatch.com/en/temporary-inbox?box="},
   {name: "Harakirimail", domain: "harakirimail.com", inbox_url: "https://harakirimail.com/inbox/"}
 ];


### PR DESCRIPTION
This extension doesn't seem to have changed for a couple of years and mailinator has changed it's URL in the meantime. Would love to see it working again as it's the main disposable email service I'm using.